### PR TITLE
Temporary fix missing method for go 1.23

### DIFF
--- a/runner/deps.go
+++ b/runner/deps.go
@@ -26,6 +26,12 @@ import (
 // suitable for passing to testing.MainStart.
 type TestDeps struct{}
 
+// InitRuntimeCoverage implements testing.testDeps.
+func (t *TestDeps) InitRuntimeCoverage() (mode string, tearDown func(coverprofile string, gocoverdir string) (string, error), snapcov func() float64) {
+	// do nothing
+	return
+}
+
 // corpusEntry is an alias to the same type as internal/fuzz.CorpusEntry.
 // We use a type alias because we don't want to export this type, and we can't
 // import internal/fuzz from testing.


### PR DESCRIPTION
I don't know the correct way of upgrading to support 1.23. Please handle with correct way.

This PR is a kind of workaround. Just added missing method.

---

Please read the CLA carefully before submitting your contribution to Mercari. Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.

https://www.mercari.com/cla/